### PR TITLE
fix pygame incorrect version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ APT_INSTALL_LIST = [
 PIP_INSTALL_LIST = [
     "gpiozero",
     'pillow',
-    "'pygame>=2.1.2'",
+    "pygame>=2.0.2",
 ]
 
 if sys.argv[1] == 'install':


### PR DESCRIPTION
Fixing error in commit f43958d859ed93bebc62971b5e8bd08f22ca395b.
Version 2.1.2 does not exist, and the script fails to run!

Closes #2 