### PR TITLE
feat: add libsox-fmt-mp3 to apt install deps in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -140,6 +140,7 @@ APT_INSTALL_LIST = [
     "python3-pyaudio",
     'libsdl2-dev',
     'libsdl2-mixer-dev',
+    'libsox-fmt-mp3',  # EdgeTTS MP3→WAV conversion
 ]
 
 PIP_INSTALL_LIST = [


### PR DESCRIPTION
## Summary

Add `libsox-fmt-mp3` to `APT_INSTALL_LIST` in `setup.py`. This is required for EdgeTTS MP3→WAV conversion via sox.

## Test

```bash
sudo apt install libsox-fmt-mp3 -y
pip install git+https://github.com/sunfounder/robot-hat.git@feat/add-libsox-fmt-mp3-dep
```